### PR TITLE
Add dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+version: 2
+updates:
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      # Check for updates to GitHub Actions once a week on Monday
+      interval: "weekly"
+      day: "monday"
+  - package-ecosystem: "pip"
+    directory: "/config/python"
+    schedule:
+      # Check for updates to GitHub Actions once a week on Monday
+      interval: "weekly"
+      day: "monday"
+   


### PR DESCRIPTION
This PR contains the basic configuration for dependabot. As the repository uses Python and GitHub Actions the corresponding ecosystems are configured to be checked once a week every Monday.

In case dependabot was not yet activated on the repository you might need to do that in the settings.

CC @mado0803 